### PR TITLE
feat: add support for Gemini CLI with GEMINI.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ vibe-rules load my-rule-name cursor -t ./my-project/.cursor-rules/custom-rule.md
 Arguments:
 
 - `<name>`: The name of the rule saved in the local store (`~/.vibe-rules/rules/`).
-- `<editor>`: The target editor/tool type. Supported: `cursor`, `windsurf`, `claude-code`, `codex`, `clinerules`, `roo`, `vscode`.
+- `<editor>`: The target editor/tool type. Supported: `cursor`, `windsurf`, `claude-code`, `gemini`, `codex`, `clinerules`, `roo`, `vscode`.
 
 Options:
 
-- `-g, --global`: Apply to the editor's global configuration path (if supported, e.g., `claude-code`, `codex`). Defaults to project-local.
+- `-g, --global`: Apply to the editor's global configuration path (if supported, e.g., `claude-code`, `gemini`, `codex`). Defaults to project-local.
 - `-t, --target <path>`: Specify a custom target file path or directory, overriding default/global paths.
 
 ### Sharing and Installing Rules via NPM
@@ -138,7 +138,7 @@ Add the `--debug` global option to any `vibe-rules` command to enable detailed d
 
 Arguments:
 
-- `<editor>`: The target editor/tool type (mandatory). Supported: `cursor`, `windsurf`, `claude-code`, `codex`, `clinerules`, `roo`, `vscode`.
+- `<editor>`: The target editor/tool type (mandatory). Supported: `cursor`, `windsurf`, `claude-code`, `gemini`, `codex`, `clinerules`, `roo`, `vscode`.
 - `[packageName]` (Optional): The specific NPM package name to install rules from. If omitted, `vibe-rules` scans all dependencies and devDependencies in your project's `package.json`.
 
 Options:
@@ -168,6 +168,10 @@ Options:
   - Appends rules wrapped in `<rule-name>` tags to `./.windsurfrules` (local) or a target file specified by `-t`. Global (`-g`) is not typically used.
 - **Claude Code (`claude-code`)**:
   - Appends/updates rules within XML-like tagged blocks in a `<!-- vibe-rules Integration -->` section in `./CLAUDE.md` (local) or `~/.claude/CLAUDE.md` (global).
+  - Each rule is encapsulated in tags like `<rule-name>...</rule-name>` within the single markdown file.
+  - Supports metadata formatting for `alwaysApply` and `globs` configurations.
+- **Gemini (`gemini`)**:
+  - Appends/updates rules within XML-like tagged blocks in a `<!-- vibe-rules Integration -->` section in `./GEMINI.md` (local) or `~/.gemini/GEMINI.md` (global).
   - Each rule is encapsulated in tags like `<rule-name>...</rule-name>` within the single markdown file.
   - Supports metadata formatting for `alwaysApply` and `globs` configurations.
 - **Codex (`codex`)**:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,9 +51,9 @@ program
   .argument("<n>", "Name of the rule to apply")
   .argument(
     "<editor>",
-    "Target editor type (cursor, windsurf, claude-code, codex, amp, clinerules, roo, zed, unified, vscode)"
+    "Target editor type (cursor, windsurf, claude-code, gemini, codex, amp, clinerules, roo, zed, unified, vscode)"
   )
-  .option("-g, --global", "Apply to global config path if supported (claude-code, codex)", false)
+  .option("-g, --global", "Apply to global config path if supported (claude-code, gemini, codex)", false)
   .option("-t, --target <path>", "Custom target path (overrides default and global)")
   .action(loadCommandAction);
 
@@ -64,10 +64,10 @@ program
   )
   .argument(
     "<editor>",
-    "Target editor type (cursor, windsurf, claude-code, codex, amp, clinerules, roo, zed, unified, vscode)"
+    "Target editor type (cursor, windsurf, claude-code, gemini, codex, amp, clinerules, roo, zed, unified, vscode)"
   )
   .argument("[packageName]", "Optional NPM package name to install rules from")
-  .option("-g, --global", "Apply to global config path if supported (claude-code, codex)", false)
+  .option("-g, --global", "Apply to global config path if supported (claude-code, gemini, codex)", false)
   .option("-t, --target <path>", "Custom target path (overrides default and global)")
   .action(installCommandAction);
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -33,6 +33,7 @@ async function clearExistingRules(
   const singleFileProviders: RuleTypeArray = [
     RuleType.WINDSURF,
     RuleType.CLAUDE_CODE,
+    RuleType.GEMINI,
     RuleType.CODEX,
   ];
   let isSingleFileProvider = singleFileProviders.includes(editorType);

--- a/src/providers/gemini-provider.ts
+++ b/src/providers/gemini-provider.ts
@@ -1,0 +1,141 @@
+import * as fs from "fs-extra/esm";
+import { readFile, writeFile } from "fs/promises";
+import * as path from "path";
+import { RuleConfig, RuleProvider, RuleGeneratorOptions, RuleType } from "../types.js";
+import { getRulePath } from "../utils/path.js";
+import { formatRuleWithMetadata, createTaggedRuleBlock } from "../utils/rule-formatter.js";
+import { saveInternalRule, loadInternalRule, listInternalRules } from "../utils/rule-storage.js";
+import chalk from "chalk";
+
+export class GeminiRuleProvider implements RuleProvider {
+  private readonly ruleType = RuleType.GEMINI;
+
+  /**
+   * Generates formatted content for Gemini including metadata.
+   * This content is intended to be placed within the <!-- vibe-rules Integration --> block.
+   */
+  generateRuleContent(config: RuleConfig, options?: RuleGeneratorOptions): string {
+    // Format the content with metadata
+    return formatRuleWithMetadata(config, options);
+  }
+
+  /**
+   * Saves a rule definition to internal storage for later use.
+   * @param config - The rule configuration.
+   * @returns Path where the rule definition was saved internally.
+   */
+  async saveRule(config: RuleConfig): Promise<string> {
+    return saveInternalRule(RuleType.GEMINI, config);
+  }
+
+  /**
+   * Loads a rule definition from internal storage.
+   * @param name - The name of the rule to load.
+   * @returns The RuleConfig if found, otherwise null.
+   */
+  async loadRule(name: string): Promise<RuleConfig | null> {
+    return loadInternalRule(RuleType.GEMINI, name);
+  }
+
+  /**
+   * Lists rule definitions available in internal storage.
+   * @returns An array of rule names.
+   */
+  async listRules(): Promise<string[]> {
+    return listInternalRules(RuleType.GEMINI);
+  }
+
+  /**
+   * Applies a rule by updating the <vibe-rules> section in the target GEMINI.md.
+   * If targetPath is omitted, it determines local vs global based on isGlobal option.
+   */
+  async appendRule(
+    name: string,
+    targetPath?: string,
+    isGlobal: boolean = false,
+    options?: RuleGeneratorOptions
+  ): Promise<boolean> {
+    const rule = await this.loadRule(name);
+    if (!rule) {
+      console.error(`Rule '${name}' not found for type ${this.ruleType}.`);
+      return false;
+    }
+
+    const destinationPath = targetPath || getRulePath(this.ruleType, name, isGlobal); // name might not be needed by getRulePath here
+
+    return this.appendFormattedRule(rule, destinationPath, isGlobal, options);
+  }
+
+  /**
+   * Formats and applies a rule directly from a RuleConfig object using XML-like tags.
+   * If a rule with the same name (tag) already exists, its content is updated.
+   */
+  async appendFormattedRule(
+    config: RuleConfig,
+    targetPath: string,
+    isGlobal?: boolean,
+    options?: RuleGeneratorOptions
+  ): Promise<boolean> {
+    const destinationPath = targetPath;
+    // Ensure the parent directory exists
+    fs.ensureDirSync(path.dirname(destinationPath));
+
+    const newBlock = createTaggedRuleBlock(config, options);
+
+    let fileContent = "";
+    if (await fs.pathExists(destinationPath)) {
+      fileContent = await readFile(destinationPath, "utf-8");
+    }
+
+    // Escape rule name for regex
+    const ruleNameRegex = config.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const regex = new RegExp(`^<${ruleNameRegex}>[\\s\\S]*?</${ruleNameRegex}>`, "m");
+
+    let updatedContent: string;
+    const match = fileContent.match(regex);
+
+    if (match) {
+      // Rule exists, replace its content
+      console.log(
+        chalk.blue(`Updating existing rule block for "${config.name}" in ${destinationPath}...`)
+      );
+      updatedContent = fileContent.replace(regex, newBlock);
+    } else {
+      // Rule doesn't exist, append it
+      // Attempt to append within <!-- vibe-rules Integration --> if possible
+      const integrationStartTag = "<!-- vibe-rules Integration -->";
+      const integrationEndTag = "<!-- /vibe-rules Integration -->";
+      const startIndex = fileContent.indexOf(integrationStartTag);
+      const endIndex = fileContent.indexOf(integrationEndTag);
+
+      console.log(
+        chalk.blue(`Appending new rule block for "${config.name}" to ${destinationPath}...`)
+      );
+
+      if (startIndex !== -1 && endIndex !== -1 && startIndex < endIndex) {
+        // Insert before the end tag of the integration block
+        const insertionPoint = endIndex;
+        const before = fileContent.slice(0, insertionPoint);
+        const after = fileContent.slice(insertionPoint);
+        updatedContent = `${before.trimEnd()}\n\n${newBlock}\n\n${after.trimStart()}`;
+      } else {
+        // Create the vibe-rules Integration block if it doesn't exist
+        if (fileContent.trim().length > 0) {
+          // File has content but no integration block, wrap everything
+          updatedContent = `<!-- vibe-rules Integration -->\n\n${fileContent.trim()}\n\n${newBlock}\n\n<!-- /vibe-rules Integration -->`;
+        } else {
+          // New/empty file, create integration block with the new rule
+          updatedContent = `<!-- vibe-rules Integration -->\n\n${newBlock}\n\n<!-- /vibe-rules Integration -->`;
+        }
+      }
+    }
+
+    try {
+      await writeFile(destinationPath, updatedContent.trim() + "\n");
+      return true;
+    } catch (error) {
+      console.error(chalk.red(`Error writing updated rules to ${destinationPath}: ${error}`));
+      return false;
+    }
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,6 +2,7 @@ import { RuleProvider, RuleType } from "../types.js";
 import { CursorRuleProvider } from "./cursor-provider.js";
 import { WindsurfRuleProvider } from "./windsurf-provider.js";
 import { ClaudeCodeRuleProvider } from "./claude-code-provider.js";
+import { GeminiRuleProvider } from "./gemini-provider.js";
 import { CodexRuleProvider } from "./codex-provider.js";
 import { AmpRuleProvider } from "./amp-provider.js";
 import { ClinerulesRuleProvider } from "./clinerules-provider.js";
@@ -20,6 +21,8 @@ export function getRuleProvider(ruleType: RuleType): RuleProvider {
       return new WindsurfRuleProvider();
     case RuleType.CLAUDE_CODE:
       return new ClaudeCodeRuleProvider();
+    case RuleType.GEMINI:
+      return new GeminiRuleProvider();
     case RuleType.CODEX:
       return new CodexRuleProvider();
     case RuleType.AMP:

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export const RuleType = {
   CURSOR: "cursor",
   WINDSURF: "windsurf",
   CLAUDE_CODE: "claude-code",
+  GEMINI: "gemini",
   CODEX: "codex",
   AMP: "amp",
   CLINERULES: "clinerules",

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -9,6 +9,7 @@ export const RULES_BASE_DIR = path.join(os.homedir(), ".vibe-rules");
 
 // Home directories for specific IDEs/Tools
 export const CLAUDE_HOME_DIR = path.join(os.homedir(), ".claude");
+export const GEMINI_HOME_DIR = path.join(os.homedir(), ".gemini");
 export const CODEX_HOME_DIR = path.join(os.homedir(), ".codex");
 export const ZED_RULES_FILE = ".rules"; // Added for Zed
 
@@ -57,6 +58,11 @@ export function getRulePath(
       return isGlobal
         ? path.join(CLAUDE_HOME_DIR, "CLAUDE.md")
         : path.join(projectRoot, "CLAUDE.md");
+    case RuleType.GEMINI:
+      // Gemini rules are GEMINI.md, either global or local
+      return isGlobal
+        ? path.join(GEMINI_HOME_DIR, "GEMINI.md")
+        : path.join(projectRoot, "GEMINI.md");
     case RuleType.CODEX:
       // Codex uses AGENTS.md (global) or AGENTS.md (local)
       return isGlobal
@@ -115,6 +121,11 @@ export function getDefaultTargetPath(
       return isGlobalHint
         ? CLAUDE_HOME_DIR // Directory
         : process.cwd(); // Project root (for local CLAUDE.md)
+    case RuleType.GEMINI:
+      // Default target depends on global hint
+      return isGlobalHint
+        ? GEMINI_HOME_DIR // Directory
+        : process.cwd(); // Project root (for local GEMINI.md)
     case RuleType.CODEX:
       // Default target depends on global hint
       return isGlobalHint
@@ -194,6 +205,11 @@ export async function editorConfigExists(
       checkPath = isGlobal
         ? path.join(CLAUDE_HOME_DIR, "CLAUDE.md")
         : path.join(projectRoot, "CLAUDE.md");
+      break;
+    case RuleType.GEMINI:
+      checkPath = isGlobal
+        ? path.join(GEMINI_HOME_DIR, "GEMINI.md")
+        : path.join(projectRoot, "GEMINI.md");
       break;
     case RuleType.CODEX:
       checkPath = isGlobal


### PR DESCRIPTION
Closes #10

This PR adds full support for Gemini CLI with GEMINI.md files, functioning exactly the same as CLAUDE.md support.

## Changes
- Add GEMINI to RuleType enum
- Create GeminiRuleProvider following Claude Code pattern
- Support both global (~/.gemini/GEMINI.md) and local (GEMINI.md) configurations
- Update path utilities to handle Gemini paths correctly
- Add Gemini to single file providers list
- Update CLI commands and documentation to include Gemini

Generated with [Claude Code](https://claude.ai/code)